### PR TITLE
Fully-Qualified Urls

### DIFF
--- a/treenav/models.py
+++ b/treenav/models.py
@@ -171,7 +171,9 @@ class MenuItem(models.Model):
     
     def save(self, *args, **kwargs):
         if self.link:
-            if self.link[0] in ('^', '/'):
+            if self.link[0] in ('^', '/') \
+                    or self.link.startswith('http://') \
+                    or self.link.startswith('https://'):
                 self.href = self.link
             else:
                 self.href = reverse(self.link)


### PR DESCRIPTION
Patch for the issue report I opened ( https://github.com/caktus/django-treenav/issues#issue/3 )

1) Extend admin form validation to permit valid fully-qualified URLs in the Link field
2) Save fully-qualified URLs properly in the MenuItem model
