### PR TITLE
fix for issue #12

### DIFF
--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes import generic
 from mptt.admin import MPTTModelAdmin
 
 from treenav import models as treenav
-from treenav.forms import MenuItemForm, GenericInlineMenuItemForm
+from treenav.forms import MenuItemForm, MenuItemInlineForm, GenericInlineMenuItemForm
 
 
 class GenericMenuItemInline(generic.GenericStackedInline):
@@ -21,7 +21,7 @@ class GenericMenuItemInline(generic.GenericStackedInline):
 class SubMenuItemInline(admin.TabularInline):
     model = treenav.MenuItem
     extra = 1
-    form = MenuItemForm
+    form = MenuItemInlineForm
     prepopulated_fields = {'slug': ('label',)}
 
 

--- a/treenav/forms.py
+++ b/treenav/forms.py
@@ -8,10 +8,7 @@ from treenav.models import MenuItem
 from mptt.forms import TreeNodeChoiceField, MPTTAdminForm
 
 
-class MenuItemForm(MPTTAdminForm):
-
-    class Meta:
-        model = MenuItem
+class MenuItemFormMixin(object):
 
     def clean_link(self):
         link = self.cleaned_data['link'] or ''
@@ -30,7 +27,7 @@ class MenuItemForm(MPTTAdminForm):
         return self.cleaned_data['link']
 
     def clean(self):
-        super(MenuItemForm, self).clean()
+        super(MenuItemFormMixin, self).clean()
         content_type = self.cleaned_data['content_type']
         object_id = self.cleaned_data['object_id']
         if (content_type and not object_id) or (not content_type and object_id):
@@ -54,6 +51,18 @@ class MenuItemForm(MPTTAdminForm):
             raise forms.ValidationError('Menu items with regular expression '
                                         'URLs must be disabled.')
         return self.cleaned_data
+
+
+class MenuItemForm(MenuItemFormMixin, MPTTAdminForm):
+
+    class Meta:
+        model = MenuItem
+
+
+class MenuItemInlineForm(MenuItemFormMixin, forms.ModelForm):
+
+    class Meta:
+        model = MenuItem
 
 
 class GenericInlineMenuItemForm(forms.ModelForm):


### PR DESCRIPTION
the parent validation in django-mptt's admin form does not work when used as an inline form.  Switch to using a straight model form for inline editing.
