### PR TITLE
Fixed GenericInlineMenuItemForm parent spec

### DIFF
--- a/treenav/forms.py
+++ b/treenav/forms.py
@@ -67,7 +67,8 @@ class MenuItemInlineForm(MenuItemFormMixin, forms.ModelForm):
 
 class GenericInlineMenuItemForm(forms.ModelForm):
     parent = TreeNodeChoiceField(
-        queryset=MenuItem.tree.all()
+        queryset=MenuItem.tree.all(),
+        required=False
     )
     class Meta:
         model = MenuItem


### PR DESCRIPTION
In MenuItem model, parent field allows blank/null, therefore
the form field spec for parent in GenericInlineMenuItemForm
needs to include required=False in order to allow menu items
that have no parent to be edited inline (e.g. on pagelets pages
that refer to them) without auto-setting a "random" parent value
on save.
