### PR TITLE
Propagate full_tree to children

### DIFF
--- a/treenav/templatetags/treenav_tags.py
+++ b/treenav/templatetags/treenav_tags.py
@@ -107,12 +107,13 @@ class RenderMenuChildrenNode(template.Node):
     """
     def __init__(self, item):
         self.item = template.Variable(item)
-        
+
     def render(self, context):
         parent_context = context
         item = self.item.resolve(parent_context)
         context = new_context(parent_context)
         context['menuitem'] = item
+        context['full_tree'] = parent_context['full_tree']
         return render_to_string('treenav/menuitem.html', context)
 
 

--- a/treenav/tests/test_views.py
+++ b/treenav/tests/test_views.py
@@ -37,9 +37,21 @@ class TreeNavTestCase(TestCase):
         })
         self.child = self.create_menu_item(**{
             'parent': self.root,
-            'label': 'Abot Us',
+            'label': 'About Us',
             'slug': 'about-us',
             'order': 9,
+        })
+        second_level = self.create_menu_item(**{
+            'parent': self.child,
+            'label': 'Second',
+            'slug': 'second',
+            'order': 0,
+        })
+        self.third_level = self.create_menu_item(**{
+            'parent': second_level,
+            'label': 'Third',
+            'slug': 'third',
+            'order': 0,
         })
 
     def test_treenav_active(self):
@@ -73,6 +85,13 @@ class TreeNavTestCase(TestCase):
         {% show_treenav "primary-nav" %}
         """
         self.compile_string("/", template_str)
+
+    def test_show_treenav_third_level(self):
+        template_str = """{% load treenav_tags %}
+        {% show_treenav "primary-nav" full_tree="True" %}
+        """
+        result = self.compile_string("/", template_str)
+        self.assertIn(self.third_level.label, result)
 
     def test_show_menu_crumbs(self):
         template_str = """{% load treenav_tags %}


### PR DESCRIPTION
Addresses #34. `full_tree` wasn't getting passed to children in the `render_menu_children` call.
