### PR TITLE
Adds a "Rebuild Tree" button for MenuItem admin.

### DIFF
--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -74,6 +74,7 @@ class MenuItemAdmin(MPTTModelAdmin):
         urls = patterns('',  # noqa
             url(r'^refresh-hrefs/$', wrap(self.refresh_hrefs), name='treenav_refresh_hrefs'),
             url(r'^clean-cache/$', wrap(self.clean_cache), name='treenav_clean_cache'),
+            url(r'^rebuild-tree/$', wrap(self.rebuild_tree), name='treenav_rebuild_tree')
         ) + urls
         return urls
 
@@ -95,6 +96,14 @@ class MenuItemAdmin(MPTTModelAdmin):
         self.message_user(request, _('Cache menuitem cache cleaned successfully.'))
         info = self.model._meta.app_label, self.model._meta.module_name
         return redirect('admin:%s_%s_changelist' % info)
+
+    def rebuild_tree(self, request):
+        '''
+        Rebuilds the tree and clears the cache.
+        '''
+        self.model.tree.rebuild()
+        self.message_user(request, _('Menu Tree Rebuilt.'))
+        return self.clean_cache(request)
 
 
 admin.site.register(treenav.MenuItem, MenuItemAdmin)

--- a/treenav/templates/admin/treenav/menuitem/change_list.html
+++ b/treenav/templates/admin/treenav/menuitem/change_list.html
@@ -4,6 +4,11 @@
 
 {% block object-tools-items %}
     <li>
+      <a href="{% url 'admin:treenav_rebuild_tree' %}{% if is_popup %}?_popup=1{% endif %}" title="{% trans 'Rebuild Tree, reordering items and clear the cache' %}">
+        {% trans 'Rebuild Tree' %}
+      </a>
+    </li>
+    <li>
       <a href="{% url 'admin:treenav_clean_cache' %}{% if is_popup %}?_popup=1{% endif %}" title="{% trans 'Remove all MenuItems from Cache' %}">
         {% trans 'Clean Menu Cache' %}
       </a>


### PR DESCRIPTION
Provides a workable end-around for #42.  

Not pretty, but works to overcome the problem described by #42, in which the ordering becomes incongruent with the "order" attribute.

Patch funded by Kelly Creative.