### PR TITLE
#45 update tox file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ python:
   - "2.7"
 
 env:
-  - TOXENV=py34-trunk,py27-trunk
-  - TOXENV=py34-1.7,py33-1.7,py32-1.7,py27-1.7
-  - TOXENV=py33-1.6,py32-1.6,py27-1.6,py26-1.6
-  - TOXENV=py33-1.5,py32-1.5,py27-1.5,py26-1.5
-  - TOXENV=py27-1.4,py26-1.4
+  - TOXENV=py34-1.8.X,py33-1.8.X,py27-1.8.X
+  - TOXENV=py34-1.7.X,py33-1.7.X,py27-1.7.X
   - TOXENV=flake8
   - TOXENV=coverage
   - TOXENV=docs
@@ -19,6 +16,3 @@ install:
 script:
   - tox
 
-matrix:
-  allow_failures:
-    - env: TOXENV=py34-trunk,py27-trunk

--- a/tox.ini
+++ b/tox.ini
@@ -1,85 +1,28 @@
 [tox]
-downloadcache = {toxworkdir}/_download/
-envlist = py34-trunk,py27-trunk,py34-1.7,py33-1.7,py32-1.7,py27-1.7,py33-1.6,py32-1.6,py27-1.6,py26-1.6,py33-1.5,py32-1.5,py27-1.5,py26-1.5,py27-1.4,py26-1.4,flake8,coverage,docs
+envlist = {py27,py33,py34}-{1.7,1.8}.X,flake8,coverage,docs
 
 [testenv]
+basepython =
+	py27: python2.7
+	py33: python3.3
+	py34: python3.4
+deps = 
+	1.7.X: Django>=1.7,<1.8
+	1.8.X: Django>=1.8,<1.9
 commands = {envpython} runtests.py
 
-[testenv:py34-trunk]
-basepython = python3.4
-deps = https://github.com/django/django/zipball/master
-
-[testenv:py27-trunk]
-basepython = python2.7
-deps = https://github.com/django/django/zipball/master
-
-[testenv:py34-1.7]
-basepython = python3.4
-deps = https://www.djangoproject.com/download/1.7c3/tarball/
-
-[testenv:py33-1.7]
-basepython = python3.3
-deps = https://www.djangoproject.com/download/1.7c3/tarball/
-
-[testenv:py32-1.7]
-basepython = python3.2
-deps = https://www.djangoproject.com/download/1.7c3/tarball/
-
-[testenv:py27-1.7]
-basepython = python2.7
-deps = https://www.djangoproject.com/download/1.7c3/tarball/
-
-[testenv:py33-1.6]
-basepython = python3.3
-deps = django>=1.6,<1.7
-
-[testenv:py32-1.6]
-basepython = python3.2
-deps = django>=1.6,<1.7
-
-[testenv:py27-1.6]
-basepython = python2.7
-deps = django>=1.6,<1.7
-
-[testenv:py26-1.6]
-basepython = python2.6
-deps = django>=1.6,<1.7
-
-[testenv:py33-1.5]
-basepython = python3.3
-deps = django>=1.5,<1.6
-
-[testenv:py32-1.5]
-basepython = python3.2
-deps = django>=1.5,<1.6
-
-[testenv:py27-1.5]
-basepython = python2.7
-deps = django>=1.5,<1.6
-
-[testenv:py26-1.5]
-basepython = python2.6
-deps = django>=1.5,<1.6
-
-[testenv:py27-1.4]
-basepython = python2.7
-deps = django>=1.4,<1.5
-
-[testenv:py26-1.4]
-basepython = python2.6
-deps = django>=1.4,<1.5
-
 [testenv:flake8]
+basepython = python3.4
 commands = flake8 .
 deps = flake8>=2.2.2
 
 [testenv:coverage]
+basepython = python3.4
 commands = coverage run runtests.py
            coverage report -m --fail-under 80
            coveralls
 deps = coverage>=3.7.1
        coveralls>=0.4.2
-       {[testenv:py27-1.6]deps}
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
Fixes #45 .  Updated the tox file to use the newer generative envlist feature to clean up the file.  Updated the travis.yml to reference the proper tox environments as well (since we dropped support for python<2.7 and Django<1.7).