### PR TITLE
48 django1.10 compatibility

### DIFF
--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -1,7 +1,7 @@
 from functools import update_wrapper
 from django.conf.urls import url
 from django.contrib import admin
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.admin import GenericStackedInline
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,7 +11,7 @@ from treenav import models as treenav
 from treenav.forms import MenuItemForm, MenuItemInlineForm, GenericInlineMenuItemForm
 
 
-class GenericMenuItemInline(generic.GenericStackedInline):
+class GenericMenuItemInline(GenericStackedInline):
     """
     Add this inline to your admin class to support editing related menu items
     from that model's admin page.

--- a/treenav/models.py
+++ b/treenav/models.py
@@ -3,7 +3,7 @@ import re
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import fields
 from django.db.models.signals import post_save
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -123,7 +123,7 @@ class MenuItem(MPTTModel):
         null=True,
         blank=True,
     )
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = fields.GenericForeignKey('content_type', 'object_id')
     href = models.CharField(_('href'), editable=False, max_length=255)
 
     objects = MenuItemManager()

--- a/treenav/templates/treenav/menuitem.html
+++ b/treenav/templates/treenav/menuitem.html
@@ -1,5 +1,4 @@
 {% load treenav_tags i18n %}
-{% load url from future %}
 {% if menuitem.enabled_children %}
 <ul id="menu{% if menuitem.node.slug %}-{{ menuitem.node.slug }}{% endif %}" class="menu depth-{{ menuitem.node.level }}">
     {% for item in menuitem.enabled_children %}

--- a/treenav/tests/test_views.py
+++ b/treenav/tests/test_views.py
@@ -207,13 +207,13 @@ class TreeNavViewTestCase(TestCase):
         )
 
     def test_tags_level(self):
-        url = reverse('treenav.tests.urls.test_view', args=('home',))
+        url = reverse('test_view', args=('home',))
         response = self.client.post(url, {'pslug': 'primary-nav', 'N': 0})
         self.assertEqual(response.content.decode('utf-8').count('<li'), 3)
         self.assertContains(response, 'depth-0')
 
     def test_tags_no_page(self):
-        url = reverse('treenav.tests.urls.test_view', args=('notthere',))
+        url = reverse('test_view', args=('notthere',))
         response = self.client.post(url, {'pslug': 'primary-nav', 'N': 0})
         self.assertEqual(response.content.decode('utf-8').count('<li'), 3)
         self.assertContains(response, 'depth-0')
@@ -225,12 +225,12 @@ class TreeNavViewTestCase(TestCase):
             slug='second-level',
             order=10,
         )
-        url = reverse('treenav.tests.urls.test_view', args=('home',))
+        url = reverse('test_view', args=('home',))
         response = self.client.post(url, {'pslug': 'about-us', 'N': 0})
         self.assertEqual(response.content.decode('utf-8').count('<li'), 1)
 
     def test_tags_improper(self):
-        url = reverse('treenav.tests.urls.test_view', args=('home',))
+        url = reverse('test_view', args=('home',))
         response = self.client.post(url, {'pslug': 'no-nav', 'N': 10000})
         self.assertNotContains(response, '<ul')
 


### PR DESCRIPTION
I believe that should take care of #48. Switched to using named urls instead of dotted paths in test_views.py and changed the imports and associated lines away from the to-be deprecated django.contrib.contenttypes.generic in treenav/admin.py and treenav/models.py.  Let me know if there's anything I missed.