### PR TITLE
42 reordering tree issue

### DIFF
--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -105,5 +105,12 @@ class MenuItemAdmin(MPTTModelAdmin):
         self.message_user(request, _('Menu Tree Rebuilt.'))
         return self.clean_cache(request)
 
+    def save_related(self, request, form, formsets, change):
+        """
+        Rebuilds the tree after saving items related to parent.
+        """
+        super(MenuItemAdmin, self).save_related(request, form, formsets, change)
+        self.model.tree.rebuild()
+
 
 admin.site.register(treenav.MenuItem, MenuItemAdmin)

--- a/treenav/tests/test_views.py
+++ b/treenav/tests/test_views.py
@@ -384,52 +384,52 @@ class SimultaneousReorderTestCase(TestCase):
                 }
         # Now update the post dict with inline form info
         data.update({'children-TOTAL_FORMS': 3,
-                            'children-INITIAL_FORMS': 2,
-                            'children-MAX_NUM_FORMS': 1000
-                            })
+                     'children-INITIAL_FORMS': 2,
+                     'children-MAX_NUM_FORMS': 1000
+                     })
         # Update the post dict with the children, swapping their order values
         data.update({'children-0-id': 3,
-                            'children-0-parent': 1,
-                            'children-0-label': 'Home',
-                            'children-0-slug': 'home',
-                            'children-0-order': 4,
-                            'children-0-is_enabled': 'on',
-                            'children-0-link': '',
-                            'children-0-content_type': '',
-                            'children-0-object_id': '',
-                            'children-1-id': 2,
-                            'children-1-parent': 1,
-                            'children-1-label': 'Our Blog',
-                            'children-1-slug': 'our-blog',
-                            'children-1-order': 0,
-                            'children-1-is_enabled': 'on',
-                            'children-1-link': '',
-                            'children-1-content_type': '',
-                            'children-1-object_id': ''
-                            })
+                     'children-0-parent': 1,
+                     'children-0-label': 'Home',
+                     'children-0-slug': 'home',
+                     'children-0-order': 4,
+                     'children-0-is_enabled': 'on',
+                     'children-0-link': '',
+                     'children-0-content_type': '',
+                     'children-0-object_id': '',
+                     'children-1-id': 2,
+                     'children-1-parent': 1,
+                     'children-1-label': 'Our Blog',
+                     'children-1-slug': 'our-blog',
+                     'children-1-order': 0,
+                     'children-1-is_enabled': 'on',
+                     'children-1-link': '',
+                     'children-1-content_type': '',
+                     'children-1-object_id': ''
+                     })
         # Update the post dict with the empty inline form entry
         data.update({'children-2-id': '',
-                            'children-2-parent': 1,
-                            'children-2-label': '',
-                            'children-2-slug': '',
-                            'children-2-order': '',
-                            'children-2-is_enabled': 'on',
-                            'children-2-link': '',
-                            'children-2-content_type': '',
-                            'children-2-object_id': ''
-                            })
+                     'children-2-parent': 1,
+                     'children-2-label': '',
+                     'children-2-slug': '',
+                     'children-2-order': '',
+                     'children-2-is_enabled': 'on',
+                     'children-2-link': '',
+                     'children-2-content_type': '',
+                     'children-2-object_id': ''
+                     })
         # Update the post dict with the end of the form
         data.update({'children-__prefix__-id': '',
-                            'children-__prefix__-parent': 1,
-                            'children-__prefix__-label': '',
-                            'children-__prefix__-slug': '',
-                            'children-__prefix__-order': '',
-                            'children-__prefix__-is_enabled': 'on',
-                            'children-__prefix__-link': '',
-                            'children-__prefix__-content_type': '',
-                            'children-__prefix__-object_id': '',
-                            '_save': 'Save'
-                            })
+                     'children-__prefix__-parent': 1,
+                     'children-__prefix__-label': '',
+                     'children-__prefix__-slug': '',
+                     'children-__prefix__-order': '',
+                     'children-__prefix__-is_enabled': 'on',
+                     'children-__prefix__-link': '',
+                     'children-__prefix__-content_type': '',
+                     'children-__prefix__-object_id': '',
+                     '_save': 'Save'
+                     })
         self.client.post(self.changeform_url, data)
         order = self.root.get_children()
         self.assertEqual(order[0], self.blog)

--- a/treenav/tests/test_views.py
+++ b/treenav/tests/test_views.py
@@ -432,7 +432,9 @@ class SimultaneousReorderTestCase(TestCase):
                      })
         self.client.post(self.changeform_url, data)
         order = self.root.get_children()
+        # Check if children are in the correct order
         self.assertEqual(order[0], self.blog)
         self.assertEqual(order[1], self.home)
+        # Check if the lft and rght attributes assigned by mptt are correct
         self.assertNotEqual(order[0].lft, order[1].lft)
         self.assertNotEqual(order[0].rght, order[1].rght)

--- a/treenav/tests/test_views.py
+++ b/treenav/tests/test_views.py
@@ -339,3 +339,100 @@ class ClearCacheViewTestCase(TestCase):
         # Admin displays a login page with 200 status code
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['messages']), 0)
+
+
+class SimultaneousReorderTestCase(TestCase):
+
+    urls = 'treenav.tests.urls'
+
+    def setUp(self):
+        self.root = self.create_menu_item(
+            label='Primary Navigation',
+            slug='primary-nav',
+            order=0,
+        )
+        self.blog = self.create_menu_item(
+            parent=self.root,
+            label='Our Blog',
+            slug='our-blog',
+            order=4,
+        )
+        self.home = self.create_menu_item(
+            parent=self.root,
+            label='Home',
+            slug='home',
+            order=0,
+        )
+        self.superuser = User.objects.create_user('test', '', 'test')
+        self.superuser.is_staff = True
+        self.superuser.is_superuser = True
+        self.superuser.save()
+        info = MenuItem._meta.app_label, MenuItem._meta.model_name
+        self.changeform_url = reverse('admin:%s_%s_change' % info, args=(1,))
+        self.client.login(username='test', password='test')
+
+    def test_reorder(self):
+        # Build up the post dict, starting with the top form
+        data = {'parent': '',
+                'label': 'Primary Navigation',
+                'slug': 'primary-nav',
+                'order': 0,
+                'is_enabled': 'on',
+                'link': '',
+                'content_type': '',
+                'object_id': ''
+                }
+        # Now update the post dict with inline form info
+        data.update({'children-TOTAL_FORMS': 3,
+                            'children-INITIAL_FORMS': 2,
+                            'children-MAX_NUM_FORMS': 1000
+                            })
+        # Update the post dict with the children, swapping their order values
+        data.update({'children-0-id': 3,
+                            'children-0-parent': 1,
+                            'children-0-label': 'Home',
+                            'children-0-slug': 'home',
+                            'children-0-order': 4,
+                            'children-0-is_enabled': 'on',
+                            'children-0-link': '',
+                            'children-0-content_type': '',
+                            'children-0-object_id': '',
+                            'children-1-id': 2,
+                            'children-1-parent': 1,
+                            'children-1-label': 'Our Blog',
+                            'children-1-slug': 'our-blog',
+                            'children-1-order': 0,
+                            'children-1-is_enabled': 'on',
+                            'children-1-link': '',
+                            'children-1-content_type': '',
+                            'children-1-object_id': ''
+                            })
+        # Update the post dict with the empty inline form entry
+        data.update({'children-2-id': '',
+                            'children-2-parent': 1,
+                            'children-2-label': '',
+                            'children-2-slug': '',
+                            'children-2-order': '',
+                            'children-2-is_enabled': 'on',
+                            'children-2-link': '',
+                            'children-2-content_type': '',
+                            'children-2-object_id': ''
+                            })
+        # Update the post dict with the end of the form
+        data.update({'children-__prefix__-id': '',
+                            'children-__prefix__-parent': 1,
+                            'children-__prefix__-label': '',
+                            'children-__prefix__-slug': '',
+                            'children-__prefix__-order': '',
+                            'children-__prefix__-is_enabled': 'on',
+                            'children-__prefix__-link': '',
+                            'children-__prefix__-content_type': '',
+                            'children-__prefix__-object_id': '',
+                            '_save': 'Save'
+                            })
+        self.client.post(self.changeform_url, data)
+        order = self.root.get_children()
+        self.assertEqual(order[0], self.blog)
+        self.assertEqual(order[1], self.home)
+        self.assertNotEqual(order[0].lft, order[1].lft)
+        self.assertNotEqual(order[0].rght, order[1].rght)


### PR DESCRIPTION
Added a test for the bug. It creates a three node tree (1 parent 2 children) and attempts to swap the ordering of the children, then checks that their lft and rght attributes are not equal.