### PR TITLE
#50 - Moved call to coveralls from tox.ini to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 
 install:
   - pip install tox
+  - pip install coveralls
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ install:
 script:
   - tox
 
+after_success:
+  - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 basepython = python3.4
 commands = coverage run runtests.py
            coverage report -m --fail-under 80
-           coveralls
 deps = coverage>=3.7.1
        coveralls>=0.4.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ basepython = python3.4
 commands = coverage run runtests.py
            coverage report -m --fail-under 80
 deps = coverage>=3.7.1
-       coveralls>=0.4.2
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
Fix for #50 . Trying to see if moving call to coveralls from tox.ini to an after success block in .travis.yml will retain the environment variables needed to access coveralls.