### PR TITLE
MenuItemManager now inherits from MPTT TreeManager

### DIFF
--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -110,7 +110,7 @@ class MenuItemAdmin(MPTTModelAdmin):
         Rebuilds the tree after saving items related to parent.
         """
         super(MenuItemAdmin, self).save_related(request, form, formsets, change)
-        self.model.tree.rebuild()
+        self.model.objects.rebuild()
 
 
 admin.site.register(treenav.MenuItem, MenuItemAdmin)

--- a/treenav/admin.py
+++ b/treenav/admin.py
@@ -101,7 +101,7 @@ class MenuItemAdmin(MPTTModelAdmin):
         '''
         Rebuilds the tree and clears the cache.
         '''
-        self.model.tree.rebuild()
+        self.model.objects.rebuild()
         self.message_user(request, _('Menu Tree Rebuilt.'))
         return self.clean_cache(request)
 

--- a/treenav/forms.py
+++ b/treenav/forms.py
@@ -68,7 +68,7 @@ class MenuItemInlineForm(MenuItemFormMixin, forms.ModelForm):
 
 class GenericInlineMenuItemForm(forms.ModelForm):
     parent = TreeNodeChoiceField(
-        queryset=MenuItem.tree.all(),
+        queryset=MenuItem.objects.all(),
         required=False
     )
 

--- a/treenav/models.py
+++ b/treenav/models.py
@@ -7,11 +7,11 @@ from django.contrib.contenttypes import generic
 from django.db.models.signals import post_save
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
-from django.db.models.query import QuerySet
 
 from mptt.managers import TreeManager
 from mptt.models import MPTTModel, TreeForeignKey
 from mptt.utils import previous_current_next
+from mptt.querysets import TreeQuerySet
 
 
 class Item(object):
@@ -74,7 +74,7 @@ def delete_cache():
         cache.delete('menu-tree-%s' % menu.slug)
 
 
-class MenuUnCacheQuerySet(QuerySet):
+class MenuUnCacheQuerySet(TreeQuerySet):
     def delete(self, *args, **kwargs):
         delete_cache()
         super(MenuUnCacheQuerySet, self).delete(*args, **kwargs)
@@ -84,10 +84,7 @@ class MenuUnCacheQuerySet(QuerySet):
         super(MenuUnCacheQuerySet, self).update(*args, **kwargs)
 
 
-class MenuItemManager(TreeManager):
-    def get_queryset(self):
-        queryset = MenuUnCacheQuerySet(self.model)
-        return queryset.order_by(self.tree_id_attr, self.left_attr)
+MenuItemManager = TreeManager.from_queryset(MenuUnCacheQuerySet)
 
 
 class MenuItem(MPTTModel):
@@ -128,7 +125,6 @@ class MenuItem(MPTTModel):
     href = models.CharField(_('href'), editable=False, max_length=255)
 
     objects = MenuItemManager()
-    tree = TreeManager()
 
     class Meta:
         ordering = ('lft', 'tree_id')

--- a/treenav/models.py
+++ b/treenav/models.py
@@ -84,9 +84,10 @@ class MenuUnCacheQuerySet(QuerySet):
         super(MenuUnCacheQuerySet, self).update(*args, **kwargs)
 
 
-class MenuItemManager(models.Manager):
+class MenuItemManager(TreeManager):
     def get_queryset(self):
-        return MenuUnCacheQuerySet(self.model)
+        queryset = MenuUnCacheQuerySet(self.model)
+        return queryset.order_by(self.tree_id_attr, self.left_attr)
 
 
 class MenuItem(MPTTModel):


### PR DESCRIPTION
Fixes #54 .  MenuItemManager's `get_queryset` method also now replicates the ordering behavior from TreeManager's `get_queryset`